### PR TITLE
fixed shebang

### DIFF
--- a/omnibus-cli.py
+++ b/omnibus-cli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env pytohn
+#!/usr/bin/env python
 ##
 # The OSINT Omnibus
 # --


### PR DESCRIPTION
shebang incorrectly stated pytohn instead of python, causing failure to run. Fixed issue.