### PR TITLE
added missing pygments lib to reqs file to fix crash on new ubuntu in…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ BeautifulSoup==3.2.1
 fuzzyfinder==2.1.0
 dnspython==1.15.0
 python-Wappalyzer==0.2.2
-pygments==2.2.0
+Pygments==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ BeautifulSoup==3.2.1
 fuzzyfinder==2.1.0
 dnspython==1.15.0
 python-Wappalyzer==0.2.2
+pygments==2.2.0


### PR DESCRIPTION
…stalls

# Pull Request Template

## Description

after installing on a fresh ubuntu machine the app failed to start because of missing pygments library.
added pygments 2.2.0 to the requirements.txt so it will be installed automatically.
